### PR TITLE
fix HOME directory detection in lixian_config.py when using sudo.

### DIFF
--- a/lixian_config.py
+++ b/lixian_config.py
@@ -1,6 +1,7 @@
 
 import os
 import os.path
+import pwd
 
 def get_config_path(filename):
 	if os.path.exists(filename):
@@ -9,7 +10,7 @@ def get_config_path(filename):
 	local_path = os.path.join(sys.path[0], filename)
 	if os.path.exists(local_path):
 		return local_path
-	user_home = os.getenv('USERPROFILE') or os.getenv('HOME')
+	user_home = os.getenv('USERPROFILE') or os.path.expanduser('~'+pwd.getpwuid(os.getuid())[0]) or os.getenv('HOME')
 	lixian_home = os.getenv('LIXIAN_HOME') or user_home
 	return os.path.join(lixian_home, filename)
 


### PR DESCRIPTION
billd / # sudo -u lovewilliam /opt/bin/node /opt/bin/lixian-portal
portal ready on http://_:3000/
Command failed: Traceback (most recent call last):
  File "/opt/xunlei/lixian-portal/xunlei-lixian/lixian_cli.py", line 63,
in <module>
    execute_command()
  File "/opt/xunlei/lixian-portal/xunlei-lixian/lixian_cli.py", line 60,
in execute_command
    commands[command](args[1:])
  File "/opt/xunlei/lixian-portal/xunlei-lixian/lixian_cli_parser.py",
line 165, in parse
    return f(parser(args_list, *args, *_kwargs))
  File
"/opt/xunlei/lixian-portal/xunlei-lixian/lixian_commands/config.py",
line 36, in lx_config
    put_config(*args)
  File "/opt/xunlei/lixian-portal/xunlei-lixian/lixian_config.py", line
78, in put_config
    global_config.put(k, v)
  File "/opt/xunlei/lixian-portal/xunlei-lixian/lixian_config.py", line
58, in put
    dump_config(self.path, self.values)
  File "/opt/xunlei/lixian-portal/xunlei-lixian/lixian_config.py", line
42, in dump_config
    with open(path, 'w') as x:
IOError: [Errno 13] Permission denied:
'/.xunlei.lixian.config'
