### PR TITLE
让 list 输出对 pipe 更友好

### DIFF
--- a/lixian_colors.py
+++ b/lixian_colors.py
@@ -40,6 +40,7 @@ class ScopedColors(console_type):
 				softspace = get_softspace(sys.stdout)
 				sys.stdout = console
 				sys.stdout.softspace = softspace
+				return console
 			def __exit__(self, type, value, traceback):
 				softspace = get_softspace(sys.stdout)
 				sys.stdout = self.stdout

--- a/lixian_colors_console.py
+++ b/lixian_colors_console.py
@@ -49,5 +49,10 @@ class Console:
 			else:
 				raise
 	def flush(self, *args):
-		self.output.flush(*args)
-
+		try:
+			self.output.flush(*args)
+		except IOError as e:
+			if e.errno == errno.EPIPE:
+				sys.exit(141)
+			else:
+				raise

--- a/lixian_colors_console.py
+++ b/lixian_colors_console.py
@@ -2,6 +2,7 @@
 __all__ = ['Console']
 
 import sys
+import errno
 
 styles = [
 	'black',
@@ -40,7 +41,13 @@ class Console:
 	def __call__(self, s):
 		self.write(s)
 	def write(self, s):
-		self.output.write(s)
+		try:
+			self.output.write(s)
+		except IOError as e:
+			if e.errno == errno.EPIPE:
+				sys.exit(141)
+			else:
+				raise
 	def flush(self, *args):
 		self.output.flush(*args)
 

--- a/lixian_commands/util.py
+++ b/lixian_commands/util.py
@@ -69,7 +69,7 @@ def output_tasks(tasks, columns, args, top=True):
 		'failed':'red',
 		}
 		c = status_colors[t['status_text']]
-		with colors(args.colors).ansi(c)():
+		with colors(args.colors).ansi(c)() as output:
 			for k in columns:
 				if k == 'n':
 					if top:
@@ -104,6 +104,7 @@ def output_tasks(tasks, columns, args, top=True):
 				else:
 					raise NotImplementedError(k)
 			print
+			output.flush()
 
 def usage(doc=lixian_help.usage, message=None):
 	if hasattr(doc, '__call__'):


### PR DESCRIPTION
如果用户的离线文件多时, 一个习惯的动作是

```
$ lx list | head
```

但是现有实现会抛出如下异常:

```
IOError: [Errno 32] Broken pipe
```

这个修改尝试捕获这个异常.

此外, `list` 操作默认取回整个离线文件列表, 当文件数较多时速度会受网络延迟的影响, 所以修改为使用 generator 遍历文件列表, 这样就可以做到 lazy fetch 文件列表.

我的离线中有 600 多个文件, 修改前后执行 `lx list | head` 网络 IO 的对比如下:

```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  162    3.029    0.019    3.029    0.019 {method 'recv' of '_socket.socket' objects}
    7    0.071    0.010    0.071    0.010 {method 'connect' of '_socket.socket' objects}

ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   42    0.756    0.018    0.756    0.018 {method 'recv' of '_socket.socket' objects}
    1    0.014    0.014    0.014    0.014 {method 'connect' of '_socket.socket' objects}
```
